### PR TITLE
feat: only include ppl not hosp at date of +ve test

### DIFF
--- a/analysis/process/process_data.R
+++ b/analysis/process/process_data.R
@@ -66,6 +66,7 @@ data_extract0 <- read_csv(
     covid_test_positive_date2 = col_date(format = "%Y-%m-%d"),
     #covid_positive_test_type = col_character(),
     covid_positive_previous_30_days = col_logical(),
+    any_covid_hospital_admission_date = col_date(format = "%Y-%m-%d"),
     symptomatic_covid_test = col_character(),
     covid_symptoms_snomed = col_date(format = "%Y-%m-%d"),
     primary_covid_hospital_discharge_date = col_date(format = "%Y-%m-%d"),
@@ -401,7 +402,7 @@ data_processed_eligible <- data_processed %>%
     # we're additionally using hospitalisation data in case there is no record
     # of a +ve test in SGSS but someone has been hospitalised with a covid
     # diagnosis (primary or not primary) in the 30 days prior their positive test
-    is.na(any_covid_hospital_admission_date)
+    is.na(any_covid_hospital_admission_date),
     #symptomatic_covid_test != "N",
     !is.na(high_risk_group_nhsd_combined) | high_risk_group_nhsd_combined != "NA",
     

--- a/analysis/process/process_data.R
+++ b/analysis/process/process_data.R
@@ -70,6 +70,8 @@ data_extract0 <- read_csv(
     covid_symptoms_snomed = col_date(format = "%Y-%m-%d"),
     primary_covid_hospital_discharge_date = col_date(format = "%Y-%m-%d"),
     any_covid_hospital_discharge_date = col_date(format = "%Y-%m-%d"),
+    hospital_discharge_date_before_eligible = col_date(format = "%Y-%m-%d"),
+    hospital_admission_date_after_eligible = col_date(format = "%Y-%m-%d"),
     age = col_integer(),
     pregnancy = col_logical(),
     pregdel = col_logical(),
@@ -396,8 +398,8 @@ data_processed_eligible <- data_processed %>%
     !is.na(elig_start),
     
     # Overall exclusion criteria
-    is.na(primary_covid_hospital_discharge_date) | (primary_covid_hospital_discharge_date < (elig_start - 30) & 
-                                                      primary_covid_hospital_discharge_date > (elig_start))
+    is.na(hospital_discharge_date_before_eligible ) | (hospital_discharge_date_before_eligible <= (elig_start))
+    
     # 
     # # Treatment specific eligibility criteria
     # (tb_symponset_treat <= 5 | tb_symponset_treat >= 0) & treatment_type == "Paxlovid",

--- a/analysis/process/process_data.R
+++ b/analysis/process/process_data.R
@@ -392,13 +392,26 @@ data_processed_eligible <- data_processed %>%
     
     # Overall eligibility criteria
     covid_test_positive == 1,
+    # in some cases, there is a +ve test, but date of +ve test was before someone became
+    # member of a high risk group. In those cases, that someone should be not included.
+    # elig_start equals the date of +ve test only if someone is a member of a high risk 
+    # group at that time
+    !is.na(elig_start),
     covid_positive_previous_30_days != 1,
+    # we're additionally using hospitalisation data in case there is no record
+    # of a +ve test in SGSS but someone has been hospitalised with a covid
+    # diagnosis (primary or not primary) in the 30 days prior their positive test
+    is.na(any_covid_hospital_admission_date)
     #symptomatic_covid_test != "N",
     !is.na(high_risk_group_nhsd_combined) | high_risk_group_nhsd_combined != "NA",
-    !is.na(elig_start),
     
     # Overall exclusion criteria
-    is.na(hospital_discharge_date_before_eligible ) | (hospital_discharge_date_before_eligible <= (elig_start))
+    # we're only including people if there is no record of a hospitalisation 
+    # before or on the date of +ve test, or when there is a record of a 
+    # hospitalisation, date of discharge is before or on date of +ve test 
+    # --> if someone is discharged on the same date as their +ve test, they're
+    #     eligible for at least  part of the day (so counted as eligible)
+    is.na(hospital_discharge_date_before_eligible ) | (hospital_discharge_date_before_eligible <= elig_start)
     
     # 
     # # Treatment specific eligibility criteria

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -321,6 +321,22 @@ study = StudyDefinition(
     },
   ),
 
+  any_covid_hospital_admission_date = patients.admitted_to_hospital(
+    returning = "date_admitted",
+    with_these_diagnoses = covid_icd10_codes,
+    with_patient_classification = ["1"], # ordinary admissions only - exclude day cases and regular attenders
+    # see https://docs.opensafely.org/study-def-variables/#sus for more info
+    # NOT USE with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"], # emergency admissions only to exclude incidental COVID
+    between = ["covid_test_positive_date - 31 days","covid_test_positive_date - 1 day"],
+    date_format = "YYYY-MM-DD",
+    find_first_match_in_period = False,
+    return_expectations = {
+      "date": {"earliest": "2021-12-20"},
+      "rate": "uniform",
+      "incidence": 0.05
+    },
+  ),
+
   # check if hospitalised before or on start_date (min of treatment date and +ve test)
   hospital_discharge_date_before_eligible = patients.admitted_to_hospital(
     returning = "date_discharged",

--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -320,6 +320,36 @@ study = StudyDefinition(
       "incidence": 0.05
     },
   ),
+
+  # check if hospitalised before or on start_date (min of treatment date and +ve test)
+  hospital_discharge_date_before_eligible = patients.admitted_to_hospital(
+    returning = "date_discharged",
+    with_patient_classification = ["1"], # ordinary admissions only - exclude day cases and regular attenders
+    # DO NOT USE with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"], # emergency admissions only to exclude incidental COVID
+    on_or_before= "covid_test_positive_date",
+    date_format = "YYYY-MM-DD",
+    find_last_match_in_period = True,
+    return_expectations = {
+      "date": {"earliest": "2021-12-20"},
+      "rate": "uniform",
+      "incidence": 0.05
+    },
+  ),
+
+  # check if hospitalised after start_date
+  hospital_admission_date_after_eligible = patients.admitted_to_hospital(
+    returning = "date_admitted",
+    with_patient_classification = ["1"], # ordinary admissions only - exclude day cases and regular attenders
+    # DO NOT USE with_admission_method=["21", "22", "23", "24", "25", "2A", "2B", "2C", "2D", "28"], # emergency admissions only to exclude incidental COVID
+    on_or_after= "covid_test_positive_date + 1 day",
+    date_format = "YYYY-MM-DD",
+    find_last_match_in_period = True,
+    return_expectations = {
+      "date": {"earliest": "2021-12-20"},
+      "rate": "uniform",
+      "incidence": 0.05
+    },
+  ),
   
   ### New supplemental oxygen requirement specifically for the management of COVID-19 symptoms
   #   (not currently possible to define/code)


### PR DESCRIPTION
This PR adds:
- `hospital_discharge_date_before_eligible` and `hospital_admission_date_after_eligible` to `study_definition`. 
- Only includes people in the eligible population who haven't been hospitalised **before or on** `elig_start` or who have been hospitalised but were discharged **before or on**`elig_start`.

Notes:
- `hospital_discharge_date_before_eligible` and `hospital_admission_date_after_eligible` use `covid_test_positive_date` io `start_date` because the variable is used for excluding people from the eligible population (and not the treated but not eligible population).